### PR TITLE
Append Homebrew-installed SDL include and library paths on MacOS

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,9 @@ lib_archive = false
 
 [env:emulator_64bits]
 platform = native@^1.1.3
-extra_scripts = support/sdl2_build_extra.py
+extra_scripts = 
+  pre:support/sdl2_paths.py ; Tries to find SDL2 include and lib paths on your system - specifically for MacOS w/ Homebrew
+  post:support/sdl2_build_extra.py
 build_flags =
   ${env.build_flags}
   ; -D LV_LOG_LEVEL=LV_LOG_LEVEL_INFO
@@ -48,10 +50,6 @@ build_flags =
   ; LVGL memory options, setup for the demo to run properly
   -D LV_MEM_CUSTOM=1
   -D LV_MEM_SIZE="(128U * 1024U)"
-
-  ; SDL2 includes, uncomment the next two lines on MAC OS if you intalled sdl via homebrew
-  ;  !find /opt/homebrew/Cellar/sdl2 -name "include" | sed "s/^/-I /"
-  ;  !find /opt/homebrew/Cellar/sdl2 -name "libSDL2.a" | xargs dirname | sed "s/^/-L /"
   
 lib_deps =
   ${env.lib_deps}

--- a/support/sdl2_paths.py
+++ b/support/sdl2_paths.py
@@ -1,0 +1,27 @@
+Import("env")
+import sys
+import os
+import glob
+
+if sys.platform.startswith("darwin"):
+    #sdl_include_path = !find /opt/homebrew/Cellar/sdl2 -name "include" | sed "s/^/-I /"
+    sdl_include = glob.glob("/opt/homebrew/Cellar/sdl2/*/include", recursive=True)
+    if sdl_include:
+        print(f"Found Homebrew SDL include path: {sdl_include[0]}")
+        env.Append(
+            CPPPATH=sdl_include[0]
+        )
+    sdl_lib = glob.glob("/opt/homebrew/Cellar/sdl2/**/libSDL2.a", recursive=True)
+    if sdl_lib:
+        print(f"Found Homebrew SDL lib path: {sdl_lib[0]}")
+        env.Append(
+            LIBPATH=os.path.dirname(sdl_lib[0])
+        )
+    
+    
+#breakpoint()
+    
+#print('NewENV=====================================')
+#print(env.Dump())
+#print('DefaultENV=====================================')
+#print(DefaultEnvironment().Dump())


### PR DESCRIPTION
Add a build script that automatically tries to adjust SDL2 include and library paths. Fixes compilation failure on MacOS 14. Not sure why the same failure was not observed on CI builds on MacOS 12